### PR TITLE
[G2J-002] Service configuration from yaml

### DIFF
--- a/example.yaml
+++ b/example.yaml
@@ -1,0 +1,16 @@
+jenkins-url: https://myhost:8443
+ci-dir: ci
+projects:
+  - path: first/
+    jobs:
+      - branch: master
+        jenkins-job: my-job
+        parameters: Some expression
+        token: A23DWDASD
+        diff-matcher: src/**
+      - branch: "*"
+        jenkins-job: job2
+  - path: second/path/
+    jobs:
+      - branch: "*"
+        job: second-job

--- a/g2j/conf/conf.go
+++ b/g2j/conf/conf.go
@@ -1,0 +1,40 @@
+package conf
+
+import (
+	"gopkg.in/yaml.v3"
+	"io/ioutil"
+)
+
+type Config struct {
+	JenkinsUrl string    `yaml:"jenkins-url"`
+	DirCI      string    `yaml:"ci-dir"`
+	Projects   []Project `yaml:",flow"`
+}
+
+type Project struct {
+	Path string
+	Jobs []Job `yaml:",flow"`
+}
+
+type Job struct {
+	Branch      string
+	Name        string
+	Parameters  string
+	Token       string
+	DiffMatcher string `yaml:"diff-matcher"`
+}
+
+func LoadConfig(path *string) (Config, error) {
+	fileBytes, readErr := ioutil.ReadFile(*path)
+	if readErr != nil {
+		return Config{}, readErr
+	} else {
+		return interpretConfig(fileBytes)
+	}
+}
+
+func interpretConfig(data []byte) (Config, error) {
+	config := Config{}
+	yamlErr := yaml.Unmarshal(data, &config)
+	return config, yamlErr
+}

--- a/g2j/conf/conf_test.go
+++ b/g2j/conf/conf_test.go
@@ -1,0 +1,117 @@
+package conf
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"testing"
+)
+
+func TestPartialConfig(t *testing.T) {
+	configYaml := `
+ci-dir: ci
+projects:
+  - path: first/
+    jobs:
+      - branch: master
+        name: my-job
+        token: A
+        diff-matcher: src/**
+    `
+
+	expectedConfig := Config{
+		JenkinsUrl: "",
+		DirCI:      "ci",
+		Projects: []Project{
+			Project{
+				Path: "first/",
+				Jobs: []Job{
+					Job{
+						Branch:      "master",
+						Name:        "my-job",
+						Parameters:  "",
+						Token:       "A",
+						DiffMatcher: "src/**",
+					},
+				},
+			},
+		},
+	}
+
+	assertParsedConfigAsExpected(&expectedConfig, &configYaml, t)
+
+}
+
+func TestFullConfig(t *testing.T) {
+	configYaml := `
+jenkins-url: https://myhost:8443
+ci-dir: ci
+projects:
+  - path: first/
+    jobs:
+      - branch: master
+        name: my-job
+        parameters: Some expression
+        token: A
+        diff-matcher: src/**
+      - branch: "*"
+        name: job2
+        parameters: Other expression
+        token: B
+        diff-matcher: any
+  - path: second/path/
+    jobs:
+      - branch: master
+        name: my-job
+        parameters: Some expression
+        token: A
+        diff-matcher: src/**
+    `
+
+	expectedConfig := Config{
+		JenkinsUrl: "https://myhost:8443",
+		DirCI:      "ci",
+		Projects: []Project{
+			Project{
+				Path: "first/",
+				Jobs: []Job{
+					Job{
+						Branch:      "master",
+						Name:        "my-job",
+						Parameters:  "Some expression",
+						Token:       "A",
+						DiffMatcher: "src/**",
+					},
+					Job{
+						Branch:      "*",
+						Name:        "job2",
+						Parameters:  "Other expression",
+						Token:       "B",
+						DiffMatcher: "any",
+					},
+				},
+			},
+			Project{
+				Path: "second/path/",
+				Jobs: []Job{
+					Job{
+						Branch:      "master",
+						Name:        "my-job",
+						Parameters:  "Some expression",
+						Token:       "A",
+						DiffMatcher: "src/**",
+					},
+				},
+			},
+		},
+	}
+
+	assertParsedConfigAsExpected(&expectedConfig, &configYaml, t)
+}
+
+func assertParsedConfigAsExpected(expected *Config, yaml *string, t *testing.T) {
+	actual, err := interpretConfig([]byte(*yaml))
+	if err != nil {
+		t.Errorf("Error during parsing: %s\n", err)
+	} else if !cmp.Equal(*expected, actual) {
+		t.Errorf("Expected:\n%s\nbut received:\n%s\n", *expected, actual)
+	}
+}

--- a/g2j/main.go
+++ b/g2j/main.go
@@ -1,17 +1,36 @@
 package main
 
 import (
-    "fmt"
-    "log"
-    "net/http"
+	"flag"
+	"fmt"
+	"github.com/th0masb/github2jenkins/g2j/conf"
+	"log"
+	"net/http"
+	"regexp"
 )
 
-func handler(w http.ResponseWriter, r *http.Request) {
-    fmt.Fprintf(w, "Hi there, I love %s!", r.URL.Path[1:])
-}
+const yamlRx = `^.*[.]ya?ml$`
+const configFlag = "config"
+const configFlagDescription = "Provides a path to the yaml file for configuring the server"
 
 func main() {
-    fmt.Printf("About to serve\n")
-    http.HandleFunc("/path", handler)
-    log.Fatal(http.ListenAndServe(":8080", nil))
+	configPath := flag.String(configFlag, "", configFlagDescription)
+	flag.Parse()
+	yamlMatcher := regexp.MustCompile(configFlag)
+	if !yamlMatcher.MatchString(*configPath) {
+		log.Fatalf("%s is not a path to a yaml file\n", *configPath)
+	}
+	log.Printf("Using configuration at %s\n", *configPath)
+	config, err := conf.LoadConfig(configPath)
+	if err == nil {
+		log.Printf("Loaded %+v\n", config)
+		//    http.HandleFunc("/path", handler)
+		//    log.Fatal(http.ListenAndServe(":8080", nil))
+	} else {
+		log.Fatalf("Failed to load config: %s\n", err)
+	}
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "Hi there, I love %s!", r.URL.Path[1:])
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/th0masb/github2jenkins
 
 go 1.14
+
+require (
+	github.com/google/go-cmp v0.5.0
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
+github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
+gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Adds initial support for passing a path to a .yaml configuration file as a command line argument which is then parsed to an internal struct which will be used to setup the forwarding rules.

closes #2 